### PR TITLE
Fix package name in `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module bitrise-steplib/steps-certificate-and-profile-installer
+module github.com/bitrise-steplib/steps-certificate-and-profile-installer
 
 go 1.15
 


### PR DESCRIPTION
### Changes
Missing prefix added to the package name in `go.mod`.

