### PR TITLE
Fix reference to test workflow

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -19,7 +19,7 @@ workflows:
         - content: |-
             #!/bin/env bash
             set -x # Do not set -e as bitrise command is expected to fail
-            bitrise run --config=./e2e/bitrise.yml utility_certificate_url_and_passphrase_not_equal
+            bitrise run --config=./e2e/bitrise.yml utility_certificate_url_and_passphrase_count_not_equal
             if [ $? -ne 1 ] ; then
               echo "Workflow was excepted to fail, exit code not 1."
               exit 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

One of the e2e tests was referencing a non-existing workflow. The test checked for failure, which did happen due to the non-existing workflow, so it resulted in a false positive.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
